### PR TITLE
fixed typos

### DIFF
--- a/03-collecting-data/ch04-types-of-survey-questions.html
+++ b/03-collecting-data/ch04-types-of-survey-questions.html
@@ -84,7 +84,7 @@
 	<li><em>Frequency:</em> &ldquo;How often do you&hellip;?&rdquo;<br />
 	Possible answers: always, often, sometimes, rarely, never</li>
 	<li><em>Quality:</em> &ldquo;In general, how do you rate the quality of&hellip;?&rdquo;<br />
-	Possible answers: excellent, good, good, fair, poor</li>
+	Possible answers: excellent, very good, good, fair, poor</li>
 	<li><em>Importance:</em> &ldquo;How important would you say {topic} is&hellip;&rdquo;<br />
 	Possible answers: very important, important, somewhat important, not at all important</li>
 </ul>
@@ -309,7 +309,7 @@
 
 <h3>Pretest</h3>
 
-<p>Pretesting means testing your survey with a few initial respondents before officially going out in the field. This allows you to get feedback to improve issues you might have with length, technical problems, or question ordering and wording. Sometimes this this step gets skipped if there&rsquo;s a tight deadline to meet, but you shouldn&rsquo;t underestimate its value. It can save a lot of time and money in the end.</p>
+<p>Pretesting means testing your survey with a few initial respondents before officially going out in the field. This allows you to get feedback to improve issues you might have with length, technical problems, or question ordering and wording. Sometimes this step gets skipped if there&rsquo;s a tight deadline to meet, but you shouldn&rsquo;t underestimate its value. It can save a lot of time and money in the end.</p>
 
 <h3>Anonymize Responses</h3>
 


### PR DESCRIPTION
In chapter four:
- The example of Likert Scale had two "good" options. I replaced one of them with "very good" so the final scale is now "excellent, very good, good, fair, poor".
- In the middle of the Pretest section there was a "this this". I removed one of them.
